### PR TITLE
pc - fix delete bug

### DIFF
--- a/spring-boot-crud/src/main/java/com/baeldung/crud/controllers/TutorAssignmentController.java
+++ b/spring-boot-crud/src/main/java/com/baeldung/crud/controllers/TutorAssignmentController.java
@@ -55,6 +55,7 @@ public class TutorAssignmentController {
         TutorAssignment a = tutorAssignmentRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid tutor assignment Id:" + id));
         tutorAssignmentRepository.delete(a);
+        model.addAttribute("tutorAssignments",tutorAssignmentRepository.findAll());
         return "index";
     }
 }


### PR DESCRIPTION
This PR fixes a bug where after you delete a tutorAssignment, the deleted assignment still shows up on the index page.

Apparently, you must reassign the model variable after making a change to it, in the controller method, as this line of code does. 

The `RepositoryControllerAdvice` isn't getting called in between when the controller method is called and the index page is rendered.   That makes sense in a way: its probably called *before* the controller method.